### PR TITLE
Imageoptimizations branch

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,10 @@ Changelog
 
 12.4-dev - (unreleased)
 -----------------------
+* Change: optimized saving of svg and png images from the charts
+  that are within a DavizVisualization upon chart editing. Now
+  only the chart that is changes re-renders it's images
+  [ichim-david refs #21894]
 
 12.3 - (2015-01-08)
 -------------------

--- a/eea/googlecharts/views/chart.py
+++ b/eea/googlecharts/views/chart.py
@@ -819,34 +819,33 @@ class SavePNGChart(Export):
             svg_obj.getField('file').getMutator(svg_obj)(kwargs.get('svg', ''))
 
             wftool = getToolByName(svg_obj, "portal_workflow")
-            workflows = wftool.getWorkflowsFor(svg_obj)
-            if len(workflows) > 0:
-                workflow = workflows[0]
-                transitions = workflow.transitions
-                state = wftool.getInfoFor(svg_obj, 'review_state')
-
+            # workflows = wftool.getWorkflowsFor(svg_obj)
+            state = wftool.getInfoFor(svg_obj, 'review_state', None)
+            if state:
+                # workflow = workflows[0]
+                # transitions = workflow.transitions
                 if state != 'visible':
-                    available_transitions = [transitions[i['id']] for i in
-                                            wftool.getTransitionsFor(svg_obj)]
-
-                    to_do = [k for k in available_transitions
-                             if k.new_state_id == 'published']
+                    # available_transitions = [transitions[i['id']] for i in
+                    #                         wftool.getTransitionsFor(svg_obj)]
+                    #
+                    # to_do = [k for k in available_transitions
+                    #          if k.new_state_id == 'published']
 
                     self.request.form['_no_emails_'] = True
-                    for item in to_do:
-                        workflow.doActionFor(svg_obj, item.id)
-                        break
-
+                    # for item in to_do:
+                    #     workflow.doActionFor(svg_obj, item.id)
+                        # break
+                    wftool.doActionFor(svg_obj, 'showPublicDraft')
                     # then make it public draft
-                    available_transitions = [transitions[i['id']] for i in
-                                            wftool.getTransitionsFor(svg_obj)]
-
-                    to_do = [k for k in available_transitions
-                             if k.new_state_id == 'visible']
-
-                    for item in to_do:
-                        workflow.doActionFor(svg_obj, item.id)
-                        break
+                    # available_transitions = [transitions[i['id']] for i in
+                    #                         wftool.getTransitionsFor(svg_obj)]
+                    #
+                    # to_do = [k for k in available_transitions
+                    #          if k.new_state_id == 'visible']
+                    #
+                    # for item in to_do:
+                    #     workflow.doActionFor(svg_obj, item.id)
+                    #     break
 
                 svg_obj.reindexObject()
                 notify(InvalidateCacheEvent(svg_obj))

--- a/eea/googlecharts/views/chart.py
+++ b/eea/googlecharts/views/chart.py
@@ -811,6 +811,16 @@ class SavePNGChart(Export):
         svg_field_data = svg_field.getRaw(svg_obj).getIterator().read()
         if svg_data == svg_field_data:
             return _("Success")
+        else:
+            # 21894 svg_data from the form and the data saved within the current
+            # svg files sometimes has the clipPath id number changed, otherwise
+            # the files are identical in which case we no longer need to perform
+            # any svg and image generation
+            pattern = re.compile('_ABSTRACT_RENDERER_ID_\d+')
+            svg_data_match = pattern.search(svg_data).group()
+            svg_field_data_matched = pattern.sub(svg_data_match, svg_field_data)
+            if svg_data == svg_field_data_matched:
+                return _("Success")
         img = super(SavePNGChart, self).__call__()
         if not img:
             return _("ERROR: An error occured while exporting your image. "

--- a/eea/googlecharts/views/chart.py
+++ b/eea/googlecharts/views/chart.py
@@ -4,7 +4,6 @@ import json
 import logging
 import urllib2
 import hashlib
-from Products.CMFCore.WorkflowCore import WorkflowException
 import lxml.etree
 import re
 from PIL import Image
@@ -780,7 +779,9 @@ class SavePNGChart(Export):
     """ Save png version of chart, including qr code and watermark
     """
 
-    def save_png(self, kwargs):
+    def save_svg_and_png(self, kwargs):
+        """ Save png out of the svg version of the chart
+        """
         if not IFolderish.providedBy(self.context):
             return _("Can't save png chart on a non-folderish object !")
         form = getattr(self.request, 'form', {})
@@ -816,7 +817,7 @@ class SavePNGChart(Export):
             # svg files sometimes has the clipPath id number changed, otherwise
             # the files are identical in which case we no longer need to perform
             # any svg and image generation
-            pattern = re.compile('_ABSTRACT_RENDERER_ID_\d+')
+            pattern = re.compile(r'_ABSTRACT_RENDERER_ID_\d+')
             svg_data_match = pattern.search(svg_data).group()
             svg_field_data_matched = pattern.sub(svg_data_match, svg_field_data)
             if svg_data == svg_field_data_matched:
@@ -872,7 +873,7 @@ class SavePNGChart(Export):
         return _("Success")
 
     def __call__(self, **kwargs):
-        return self.save_png(kwargs)
+        return self.save_svg_and_png(kwargs)
 
 
 class SetThumb(BrowserView):


### PR DESCRIPTION
Added  a few optimizations to the process of saving the svg and png charts that are rendered when saving any change within the daviz edit page.

Few things that are included:
1. ExcludeFromNavigation and workflow change is done only if the object is new and state isn't already
   visible
2. Svg is no longer changed if the svg from the request is the same as the one already found
3. Images are no longer converted if the svg is the same
4. Cache invalidation is performed only if the object isn't just added

This change reduces the time it takes for a daviz with 10 charts when saving from 0.4 sec for each chart to just 0.4sec for the chart that actually has the svg and image changed.